### PR TITLE
Add beacon_id and event_slug parameters to shared library

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,47 @@ pipeline {
 }
 ```
 
+### Example: *Using beacon_id and event_slug parameters*
+
+This example demonstrates how to use the optional parameters for tracking and integration purposes.
+
+```groovy
+@Library("ethiack-library")_
+import groovy.json.JsonSlurper
+
+pipeline {
+    agent any
+    
+    environment {
+        ETHIACK_API_KEY = credentials('ethiack-api-key')
+        ETHIACK_API_SECRET = credentials('ethiack-api-secret')
+    }
+
+    stages {
+        stage('Ethiack Scan') {
+            steps {
+                script {                 
+                    def buildNumber = env.BUILD_NUMBER.toInteger()
+                    def releaseVersion = "v1.2.3"
+                    
+                    // Launch a scan with tracking information
+                    def job = ethiack.launchJob(
+                        "https://example.ethiack.com:443",
+                        buildNumber,  // beacon_id for build tracking
+                        "release-${releaseVersion}" // event_slug for release tracking
+                    )
+                    
+                    def resp = ethiack.awaitJob(job.uuid, Severity.MEDIUM, false)
+                    if(resp.success == false) {
+                        error(resp.message)
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
 
 ### Available commands
 
@@ -180,10 +221,12 @@ A complete list of the available commands is provided below.
 
 > __Description:__ Check if the provided URL is valid and the scan is authorized for the organization.
 >
-> __Signature:__ `Boolean check(String url) {...}`
+> __Signature:__ `Boolean check(String url, Integer beacon_id = null, String event_slug = null, Boolean failOnBadStatus = false) {...}`
 > 
 > __Parameters:__ 
 > - `url`: URL to check
+> - `beacon_id`: Optional beacon ID to associate with the check
+> - `event_slug`: Optional event slug to associate with the check
 > - `failOnBadStatus`: If true, an error will be raised if the operation fails
 >
 > __Returns:__
@@ -202,15 +245,17 @@ A complete list of the available commands is provided below.
 
 > __Description:__ Launch a new job for the provided URL if the provided URL is valid and the organization has scan minutes available.
 >
-> __Signature:__ `Map launchJob(String url, Boolean failOnBadStatus = true) {...}`
+> __Signature:__ `Map launchJob(String url, Integer beacon_id = null, String event_slug = null, Boolean failOnBadStatus = true) {...}`
 > 
 > __Parameters:__ 
 > - `url`: URL to scan.
+> - `beacon_id`: Optional beacon ID to associate with the job
+> - `event_slug`: Optional event slug to associate with the job
 > - `failOnBadStatus`: If `true`, an error will be raised if the operation fails
 > 
 > __Returns:__
 > 
-> - Map object with the information abou the launched job
+> - Map object with the information about the launched job
 
 </details>
 

--- a/vars/ethiack.groovy
+++ b/vars/ethiack.groovy
@@ -8,16 +8,25 @@ import com.ethiack.Requests
  * Check if provided URL is valid and authorized for the organization.
  *
  * @param url URL to check
+ * @param beacon_id Optional beacon ID to associate with the check
+ * @param event_slug Optional event slug to associate with the check
  * @param failOnBadStatus if true, an error will be raised if the operation fails
  * @return true if URL is valid and if the organization has scan minutes available, false otherwise
  */
-Boolean check(String url, Boolean failOnBadStatus = false) {
+Boolean check(String url, Integer beacon_id = null, String event_slug = null, Boolean failOnBadStatus = false) {
     Requests r = new Requests(env.ETHIACK_API_KEY, env.ETHIACK_API_SECRET);
-    String json = JsonOutput.toJson(   
-        [url: url] 
-    );
-    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/check";    
-    HttpResponse response =  r.doPostHttpRequestWithJson(json, requestUrl, failOnBadStatus);
+
+    def payload = [url: url]
+    if (beacon_id != null) {
+        payload.beacon_id = beacon_id
+    }
+    if (event_slug != null) {
+        payload.event_slug = event_slug
+    }
+
+    String json = JsonOutput.toJson(payload);
+    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/check";
+    HttpResponse response = r.doPostHttpRequestWithJson(json, requestUrl, failOnBadStatus);
     return response.statusCode >= 200 && response.statusCode < 400;
 }
 
@@ -26,15 +35,24 @@ Boolean check(String url, Boolean failOnBadStatus = false) {
  * Launch a new job if the provided URL is valid and the organization has scan minutes available.
  *
  * @param url URL to scan
+ * @param beacon_id Optional beacon ID to associate with the job
+ * @param event_slug Optional event slug to associate with the job
  * @param failOnBadStatus if true, an error will be raised if the operation fails
- * @return Map object with the information abou the launched job
+ * @return Map object with the information about the launched job
  */
-Map launchJob(String url, Boolean failOnBadStatus = true) {
+Map launchJob(String url, Integer beacon_id = null, String event_slug = null, Boolean failOnBadStatus = true) {
     Requests r = new Requests(env.ETHIACK_API_KEY, env.ETHIACK_API_SECRET);
-    String json = JsonOutput.toJson(   
-        [url: url] 
-    );
-    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/launch";    
+
+    def payload = [url: url]
+    if (beacon_id != null) {
+        payload.beacon_id = beacon_id
+    }
+    if (event_slug != null) {
+        payload.event_slug = event_slug
+    }
+
+    String json = JsonOutput.toJson(payload);
+    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/launch";
     HttpResponse response = r.doPostHttpRequestWithJson(json, requestUrl, failOnBadStatus);
     return response.body;
 }
@@ -48,8 +66,8 @@ Map launchJob(String url, Boolean failOnBadStatus = true) {
  */
 void cancelJob(String jobUuid, Boolean failOnBadStatus = true) {
     Requests r = new Requests(env.ETHIACK_API_KEY, env.ETHIACK_API_SECRET);
-    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid/cancel";    
-    HttpResponse response = r.doPostHttpRequestWithJson("{}", requestUrl, failOnBadStatus);    
+    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid/cancel";
+    HttpResponse response = r.doPostHttpRequestWithJson("{}", requestUrl, failOnBadStatus);
 }
 
 
@@ -61,7 +79,7 @@ void cancelJob(String jobUuid, Boolean failOnBadStatus = true) {
  */
 Map listJobs(Boolean failOnBadStatus = true) {
     Requests r = new Requests(env.ETHIACK_API_KEY, env.ETHIACK_API_SECRET);
-    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/";    
+    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/";
     HttpResponse response = r.doGetHttpRequest(requestUrl, failOnBadStatus);
     return response.body;
 }
@@ -76,9 +94,9 @@ Map listJobs(Boolean failOnBadStatus = true) {
  */
 Map getJobInfo(String jobUuid, Boolean failOnBadStatus = true) {
     Requests r = new Requests(env.ETHIACK_API_KEY, env.ETHIACK_API_SECRET);
-    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid";    
+    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid";
     HttpResponse response = r.doGetHttpRequest(requestUrl, failOnBadStatus);
-    return response.body.job;    
+    return response.body.job;
 }
 
 
@@ -91,14 +109,14 @@ Map getJobInfo(String jobUuid, Boolean failOnBadStatus = true) {
  */
 String getJobStatus(String jobUuid, Boolean failOnBadStatus = true) {
     Requests r = new Requests(env.ETHIACK_API_KEY, env.ETHIACK_API_SECRET);
-    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid/status";    
+    String requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid/status";
     HttpResponse response = r.doGetHttpRequest(requestUrl, failOnBadStatus);
     return response.body.status;
 }
 
 
 /**
- * Get job success status. A job is considered unsucessful if it contains findings with a greater or equal severity to the one provided.
+ * Get job success status. A job is considered unsuccessful if it contains findings with a greater or equal severity to the one provided.
  *
  * @param jobUuid UUID of the job
  * @param severity severity of findings to check for. Defaults to medium.
@@ -109,9 +127,9 @@ Map getJobSuccess(String jobUuid, String severity = null, Boolean failOnBadStatu
     Requests r = new Requests(env.ETHIACK_API_KEY, env.ETHIACK_API_SECRET);
     String requestUrl;
     if (severity == null) {
-        requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid/success";    
+        requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid/success";
     } else {
-        requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid/success?severity=$severity";    
+        requestUrl = "${API.BASE_URL}/${API.ENDPOINT}/$jobUuid/success?severity=$severity";
     }
     HttpResponse response = r.doGetHttpRequest(requestUrl, failOnBadStatus);
     return response.body;


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `ethiack` library, including the addition of optional parameters for tracking purposes, improvements to documentation, and correction of a typo. The most important changes are summarized below:

### Enhancements to `ethiack` library:

* Added optional parameters `beacon_id` and `event_slug` to the `check` and `launchJob` methods to allow for tracking and integration purposes. [[1]](diffhunk://#diff-eeddd69b98afeb11a7c906fc8ea964802ca2c93fbc80af34b07ac9b96ec3334fR11-R27) [[2]](diffhunk://#diff-eeddd69b98afeb11a7c906fc8ea964802ca2c93fbc80af34b07ac9b96ec3334fR38-R54)
* Updated the example in `README.md` to demonstrate the usage of the new optional parameters.

### Documentation improvements:

* Updated the method signatures in `README.md` to reflect the addition of the new optional parameters. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L183-R229) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L205-R258)

### Typo correction:

* Corrected a typo in the `getJobStatus` method documentation from "unsucessful" to "unsuccessful".