### PR TITLE
ci: update commitlint config

### DIFF
--- a/.github/configs/commitlint.config.js
+++ b/.github/configs/commitlint.config.js
@@ -1,26 +1,9 @@
-const { maxLineLength } = require("@commitlint/ensure");
-
-const bodyMaxLineLength = 100;
-
-const validateBodyMaxLengthIgnoringDeps = (parsedCommit) => {
-  const { type, scope, body } = parsedCommit;
-  const isDepsCommit = type === "chore" && scope === "release";
-
-  return [
-    isDepsCommit || !body || maxLineLength(body, bodyMaxLineLength),
-    `body's lines must not be longer than ${bodyMaxLineLength}`,
-  ];
-};
-
 module.exports = {
-  extends: ["@commitlint/config-conventional"],
-  plugins: ["commitlint-plugin-function-rules"],
+  extends: ['@commitlint/config-conventional'],
   rules: {
-    "body-max-line-length": [0],
-    "function-rules/body-max-line-length": [
-      2,
-      "always",
-      validateBodyMaxLengthIgnoringDeps,
-    ],
+	'body-max-line-length': [1, 'always', 100], // warning
+	'header-max-length': [1, 'always', 100], // warning
+	'footer-max-line-length': [1, 'always', 100], // warning
+	'subject-case': [1, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']], // warning
   },
-};
+}


### PR DESCRIPTION
This pull request includes changes to the commit linting configuration to simplify and standardize the rules.

Changes to commit linting configuration:

* [`.github/configs/commitlint.config.js`](diffhunk://#diff-5b1e7ff4de00622887b1a190cb070f404b524c95c9d24d34f26039f31bda26bfL1-R9): Removed custom validation function `validateBodyMaxLengthIgnoringDeps` and replaced it with standard linting rules for body, header, and footer line lengths, and subject case.